### PR TITLE
Add project list preferences and project search filter

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -85,7 +85,7 @@
     "projects_list__updated_at": "Aktualisiert am",
 
     "projects_list__search_hint": "Projekte filtern...",
-    "projects_list__not_loaded_hint": "Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert.",
+    "projects_list__not_loaded_hint": "Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert. Geben Sie eine Suche ein (auch leer möglich) und bestätigen Sie, um Projekte zu laden.",
     "projects_list__load_button": "Projekte laden",
 
     "analytics_consent_request__title": "Technische Daten teilen",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -66,6 +66,10 @@
     "profile_logout_description": "Von Ihrem Konto abmelden",
     "profile_logout_button": "Abmelden",
 
+    "profile_project_filters_title": "Projektfilter",
+    "profile_project_filters_only_with_tasks": "Nur Projekte mit Aufgaben anzeigen",
+    "profile_project_filters_lazy_load": "Projektliste nicht automatisch laden",
+
     "calendar_title": "Kalenderbenachrichtigungen",
     "calendar_connect": "Kalender verbinden",
     "calendar_disconnect": "Kalender trennen",
@@ -79,6 +83,10 @@
 
     "projects_list__title": "Projekte",
     "projects_list__updated_at": "Aktualisiert am",
+
+    "projects_list__search_hint": "Projekte filtern...",
+    "projects_list__not_loaded_hint": "Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert.",
+    "projects_list__load_button": "Projekte laden",
 
     "analytics_consent_request__title": "Technische Daten teilen",
     "analytics_consent_request__text": "Hilf uns, die Stabilität und Leistung der App zu verbessern, indem du anonyme Absturzberichte und Sitzungsdaten teilst. Es werden keine personenbezogenen Daten erfasst.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -87,6 +87,7 @@
     "projects_list__search_hint": "Projekte filtern...",
     "projects_list__not_loaded_hint": "Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert. Geben Sie eine Suche ein (auch leer möglich) und bestätigen Sie, um Projekte zu laden.",
     "projects_list__load_button": "Projekte laden",
+    "projects_list__favorites_only": "Nur Favoriten",
 
     "analytics_consent_request__title": "Technische Daten teilen",
     "analytics_consent_request__text": "Hilf uns, die Stabilität und Leistung der App zu verbessern, indem du anonyme Absturzberichte und Sitzungsdaten teilst. Es werden keine personenbezogenen Daten erfasst.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -85,7 +85,7 @@
     "projects_list__updated_at": "Updated",
 
     "projects_list__search_hint": "Filter projects...",
-    "projects_list__not_loaded_hint": "Project list loading is disabled in your profile settings.",
+    "projects_list__not_loaded_hint": "Project list loading is disabled in your profile settings. Enter a search (can be empty) and submit to load projects.",
     "projects_list__load_button": "Load projects",
 
     "analytics_consent_request__title": "Share technical data",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -66,6 +66,10 @@
     "profile_logout_description": "Sign out of your account",
     "profile_logout_button": "Sign out",
 
+    "profile_project_filters_title": "Project filters",
+    "profile_project_filters_only_with_tasks": "Show only projects with tasks",
+    "profile_project_filters_lazy_load": "Do not load project list automatically",
+
     "calendar_title": "Calendar notifications",
     "calendar_connect": "Connect calendar",
     "calendar_disconnect": "Disconnect calendar",
@@ -79,6 +83,10 @@
 
     "projects_list__title": "Projects",
     "projects_list__updated_at": "Updated",
+
+    "projects_list__search_hint": "Filter projects...",
+    "projects_list__not_loaded_hint": "Project list loading is disabled in your profile settings.",
+    "projects_list__load_button": "Load projects",
 
     "analytics_consent_request__title": "Share technical data",
     "analytics_consent_request__text": "Help us improve app stability and performance by sharing anonymous crash reports and session data. No personal information is collected.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -87,6 +87,7 @@
     "projects_list__search_hint": "Filter projects...",
     "projects_list__not_loaded_hint": "Project list loading is disabled in your profile settings. Enter a search (can be empty) and submit to load projects.",
     "projects_list__load_button": "Load projects",
+    "projects_list__favorites_only": "Favorites only",
 
     "analytics_consent_request__title": "Share technical data",
     "analytics_consent_request__text": "Help us improve app stability and performance by sharing anonymous crash reports and session data. No personal information is collected.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -434,6 +434,24 @@ abstract class AppLocalizations {
   /// **'Sign out'**
   String get profile_logout_button;
 
+  /// No description provided for @profile_project_filters_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Project filters'**
+  String get profile_project_filters_title;
+
+  /// No description provided for @profile_project_filters_only_with_tasks.
+  ///
+  /// In en, this message translates to:
+  /// **'Show only projects with tasks'**
+  String get profile_project_filters_only_with_tasks;
+
+  /// No description provided for @profile_project_filters_lazy_load.
+  ///
+  /// In en, this message translates to:
+  /// **'Do not load project list automatically'**
+  String get profile_project_filters_lazy_load;
+
   /// No description provided for @calendar_title.
   ///
   /// In en, this message translates to:
@@ -493,6 +511,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Updated'**
   String get projects_list__updated_at;
+
+  /// No description provided for @projects_list__search_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter projects...'**
+  String get projects_list__search_hint;
+
+  /// No description provided for @projects_list__not_loaded_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Project list loading is disabled in your profile settings.'**
+  String get projects_list__not_loaded_hint;
+
+  /// No description provided for @projects_list__load_button.
+  ///
+  /// In en, this message translates to:
+  /// **'Load projects'**
+  String get projects_list__load_button;
 
   /// No description provided for @analytics_consent_request__title.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -521,7 +521,7 @@ abstract class AppLocalizations {
   /// No description provided for @projects_list__not_loaded_hint.
   ///
   /// In en, this message translates to:
-  /// **'Project list loading is disabled in your profile settings.'**
+  /// **'Project list loading is disabled in your profile settings. Enter a search (can be empty) and submit to load projects.'**
   String get projects_list__not_loaded_hint;
 
   /// No description provided for @projects_list__load_button.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -529,6 +529,7 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Load projects'**
   String get projects_list__load_button;
+  String get projects_list__favorites_only;
 
   /// No description provided for @analytics_consent_request__title.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -179,6 +179,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profile_logout_button => 'Abmelden';
 
   @override
+  String get profile_project_filters_title => 'Projektfilter';
+
+  @override
+  String get profile_project_filters_only_with_tasks =>
+      'Nur Projekte mit Aufgaben anzeigen';
+
+  @override
+  String get profile_project_filters_lazy_load =>
+      'Projektliste nicht automatisch laden';
+
+  @override
   String get calendar_title => 'Kalenderbenachrichtigungen';
 
   @override
@@ -209,6 +220,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get projects_list__updated_at => 'Aktualisiert am';
+
+  @override
+  String get projects_list__search_hint => 'Projekte filtern...';
+
+  @override
+  String get projects_list__not_loaded_hint =>
+      'Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert.';
+
+  @override
+  String get projects_list__load_button => 'Projekte laden';
 
   @override
   String get analytics_consent_request__title => 'Technische Daten teilen';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -226,7 +226,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get projects_list__not_loaded_hint =>
-      'Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert.';
+      'Das Laden der Projektliste ist in Ihren Profileinstellungen deaktiviert. Geben Sie eine Suche ein (auch leer möglich) und bestätigen Sie, um Projekte zu laden.';
 
   @override
   String get projects_list__load_button => 'Projekte laden';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -232,6 +232,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get projects_list__load_button => 'Projekte laden';
 
   @override
+  String get projects_list__favorites_only => 'Nur Favoriten';
+
+  @override
   String get analytics_consent_request__title => 'Technische Daten teilen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -231,6 +231,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projects_list__load_button => 'Load projects';
 
   @override
+  String get projects_list__favorites_only => 'Favorites only';
+
+  @override
   String get analytics_consent_request__title => 'Share technical data';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -179,6 +179,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profile_logout_button => 'Sign out';
 
   @override
+  String get profile_project_filters_title => 'Project filters';
+
+  @override
+  String get profile_project_filters_only_with_tasks =>
+      'Show only projects with tasks';
+
+  @override
+  String get profile_project_filters_lazy_load =>
+      'Do not load project list automatically';
+
+  @override
   String get calendar_title => 'Calendar notifications';
 
   @override
@@ -208,6 +219,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projects_list__updated_at => 'Updated';
+
+  @override
+  String get projects_list__search_hint => 'Filter projects...';
+
+  @override
+  String get projects_list__not_loaded_hint =>
+      'Project list loading is disabled in your profile settings.';
+
+  @override
+  String get projects_list__load_button => 'Load projects';
 
   @override
   String get analytics_consent_request__title => 'Share technical data';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -225,7 +225,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projects_list__not_loaded_hint =>
-      'Project list loading is disabled in your profile settings.';
+      'Project list loading is disabled in your profile settings. Enter a search (can be empty) and submit to load projects.';
 
   @override
   String get projects_list__load_button => 'Load projects';

--- a/lib/modules/profile/profile_module.dart
+++ b/lib/modules/profile/profile_module.dart
@@ -4,6 +4,7 @@ import 'package:open_project_time_tracker/modules/authorization/domain/user_data
 import 'package:open_project_time_tracker/modules/calendar/domain/calendar_connection_service.dart';
 import 'package:open_project_time_tracker/modules/calendar/domain/calendar_notifications_service.dart';
 import 'package:open_project_time_tracker/modules/profile/ui/profile_bloc.dart';
+import 'package:open_project_time_tracker/modules/task_selection/domain/settings_repository.dart';
 
 @module
 abstract class ProfileModule {
@@ -13,10 +14,12 @@ abstract class ProfileModule {
     CalendarNotificationsService calendarNotificationsService,
     UserDataRepository userDataRepository,
     CalendarConnectionService calendarConnectionService,
+    SettingsRepository settingsRepository,
   ) => ProfileBloc(
     authService,
     calendarNotificationsService,
     userDataRepository,
     calendarConnectionService,
+    settingsRepository,
   );
 }

--- a/lib/modules/profile/ui/profile_page.dart
+++ b/lib/modules/profile/ui/profile_page.dart
@@ -104,6 +104,16 @@ class ProfilePage
 
             const SizedBox(height: 24),
 
+            // Project Filters Section
+            _buildSectionTitle(
+              context,
+              AppLocalizations.of(context).profile_project_filters_title,
+            ),
+            const SizedBox(height: 8),
+            _buildProjectFiltersTile(context, state),
+
+            const SizedBox(height: 24),
+
             // Logout Section
             _buildSectionTitle(
               context,
@@ -171,6 +181,31 @@ class ProfilePage
         title: Text(AppLocalizations.of(context).profile_logout_description),
         trailing: const Icon(Icons.chevron_right),
         onTap: context.read<ProfileBloc>().logout,
+      ),
+    );
+  }
+
+  Widget _buildProjectFiltersTile(BuildContext context, ProfileState state) {
+    return ConfiguredCard(
+      child: Column(
+        children: [
+          SwitchListTile(
+            value: state.showOnlyProjectsWithTasks,
+            title: Text(
+              AppLocalizations.of(context)
+                  .profile_project_filters_only_with_tasks,
+            ),
+            onChanged: context.read<ProfileBloc>().setShowOnlyProjectsWithTasks,
+          ),
+          const Divider(height: 1),
+          SwitchListTile(
+            value: state.doNotLoadProjectList,
+            title: Text(
+              AppLocalizations.of(context).profile_project_filters_lazy_load,
+            ),
+            onChanged: context.read<ProfileBloc>().setDoNotLoadProjectList,
+          ),
+        ],
       ),
     );
   }

--- a/lib/modules/task_selection/domain/projects_repository.dart
+++ b/lib/modules/task_selection/domain/projects_repository.dart
@@ -5,6 +5,7 @@ abstract class ProjectsRepository {
     int? pageSize,
     bool sortByName = false,
     bool assignedToUser = false,
+    bool favoritesOnly = false,
   });
 }
 

--- a/lib/modules/task_selection/domain/projects_repository.dart
+++ b/lib/modules/task_selection/domain/projects_repository.dart
@@ -10,11 +10,15 @@ abstract class ProjectsRepository {
 
 class Project {
   final String id;
+  /// Numeric OpenProject id as returned by the API ("id"), used for reliable
+  /// mapping with work package project links.
+  final int? numericId;
   final String title;
   final DateTime? updatedAt;
 
   Project({
     required this.id,
+    required this.numericId,
     required this.title,
     required this.updatedAt,
   });

--- a/lib/modules/task_selection/domain/settings_repository.dart
+++ b/lib/modules/task_selection/domain/settings_repository.dart
@@ -12,4 +12,17 @@ abstract class SettingsRepository {
 
   Future<bool?> get analyticsConsent;
   Future<void> setAnalyticsConsent(bool value);
+
+  /// Filter projects to only those that have tasks.
+  ///
+  /// This is used in the project selection list.
+  Future<bool> get showOnlyProjectsWithTasks;
+  Future<void> setShowOnlyProjectsWithTasks(bool value);
+
+  /// Do not load the project list automatically.
+  ///
+  /// When enabled, the project selection list will require a manual refresh/
+  /// load trigger by the user.
+  Future<bool> get doNotLoadProjectList;
+  Future<void> setDoNotLoadProjectList(bool value);
 }

--- a/lib/modules/task_selection/domain/work_packages_repository.dart
+++ b/lib/modules/task_selection/domain/work_packages_repository.dart
@@ -5,6 +5,51 @@ abstract class WorkPackagesRepository {
     Set<int>? statuses,
     String? user,
   });
+
+  /// Returns a single page of work packages including pagination metadata.
+  ///
+  /// OpenProject API v3 returns collections that may be paginated. Pagination
+  /// metadata includes `total`, `count`, `pageSize` and `offset` (page number).
+  ///
+  /// See: https://www.openproject.org/docs/api/collections/
+  Future<WorkPackagesPage> listPaged({
+    String? projectId,
+    int? pageSize,
+    int? offset,
+    Set<int>? statuses,
+    String? user,
+  });
+}
+
+class WorkPackagesPage {
+  final List<WorkPackage> items;
+  final int total;
+  final int count;
+  final int? pageSize;
+  final int? offset;
+
+  const WorkPackagesPage({
+    required this.items,
+    required this.total,
+    required this.count,
+    required this.pageSize,
+    required this.offset,
+  });
+
+  bool get hasNext {
+    final ps = pageSize;
+    final off = offset;
+    if (ps == null || off == null) return false;
+    if (count <= 0) return false;
+    return (off * ps) < total;
+  }
+
+  int? get nextOffset {
+    if (!hasNext) return null;
+    final off = offset;
+    if (off == null) return null;
+    return off + 1;
+  }
 }
 
 enum WorkPackageAssigneeType {

--- a/lib/modules/task_selection/infrastructure/api_projects_repository.dart
+++ b/lib/modules/task_selection/infrastructure/api_projects_repository.dart
@@ -41,6 +41,7 @@ class ApiProjectsRepository implements ProjectsRepository {
     return response.projects
         .map((element) => Project(
               id: element.id,
+              numericId: element.numericId,
               title: element.title,
               updatedAt: element.updatedAt,
             ))

--- a/lib/modules/task_selection/infrastructure/api_projects_repository.dart
+++ b/lib/modules/task_selection/infrastructure/api_projects_repository.dart
@@ -13,6 +13,7 @@ class ApiProjectsRepository implements ProjectsRepository {
     int? pageSize,
     bool sortByName = false,
     bool assignedToUser = false,
+    bool favoritesOnly = false,
   }) async {
     List<String> filters = [];
     if (userId != null) {
@@ -24,6 +25,9 @@ class ApiProjectsRepository implements ProjectsRepository {
     }
     if (assignedToUser) {
       filters.add('{"member_of":{"operator":"=","values":["t"]}}');
+    }
+    if (favoritesOnly) {
+      filters.add('{"favorited":{"operator":"=","values":["t"]}}');
     }
     final filtersString = '[${filters.join(', ')}]';
 

--- a/lib/modules/task_selection/infrastructure/api_work_packages_repository.dart
+++ b/lib/modules/task_selection/infrastructure/api_work_packages_repository.dart
@@ -13,14 +13,34 @@ class ApiWorkPackagesRepository implements WorkPackagesRepository {
     Set<int>? statuses,
     String? user,
   }) async {
+    final page = await listPaged(
+      projectId: projectId,
+      pageSize: pageSize,
+      offset: 1,
+      statuses: statuses,
+      user: user,
+    );
+    return page.items;
+  }
+
+  @override
+  Future<WorkPackagesPage> listPaged({
+    String? projectId,
+    int? pageSize,
+    int? offset,
+    Set<int>? statuses,
+    String? user,
+  }) async {
     List<String> filters = [];
 
     if (user != null) {
-      filters.add('{"assigneeOrGroup":{"operator":"=","values":["$user"]}}');
+      filters.add(
+          '{"assigneeOrGroup":{"operator":"=","values":["$user"]}}');
     }
     if (statuses != null && statuses.isNotEmpty) {
       final statusesString = statuses.map((e) => '"$e"').join(', ');
-      filters.add('{"status":{"operator":"=","values":[$statusesString]}}');
+      filters.add(
+          '{"status":{"operator":"=","values":[$statusesString]}}');
     } else {
       filters.add('{"status":{"operator":"o","values":[]}}');
     }
@@ -32,34 +52,45 @@ class ApiWorkPackagesRepository implements WorkPackagesRepository {
         projectId: projectId,
         filters: filtersString,
         pageSize: pageSize,
+        offset: offset,
       );
     } else {
       response = await restApi.workPackages(
         filters: filtersString,
         pageSize: pageSize,
+        offset: offset,
       );
     }
 
-    return response.workPackages
+    final items = response.workPackages
         .map(
           (e) => WorkPackage(
-              id: e.id,
-              subject: e.subject,
-              href: e.href,
-              projectTitle: e.projectTitle,
-              projectHref: e.projectHref,
-              priority: e.priority,
-              status: e.status,
-              assignee: WorkPackageAssignee(
-                type: switch (e.assignee.type) {
-                  WorkPackageAssigneeTypeResponse.user =>
-                    WorkPackageAssigneeType.user,
-                  WorkPackageAssigneeTypeResponse.group =>
-                    WorkPackageAssigneeType.group,
-                },
-                title: e.assignee.title,
-              )),
+            id: e.id,
+            subject: e.subject,
+            href: e.href,
+            projectTitle: e.projectTitle,
+            projectHref: e.projectHref,
+            priority: e.priority,
+            status: e.status,
+            assignee: WorkPackageAssignee(
+              type: switch (e.assignee.type) {
+                WorkPackageAssigneeTypeResponse.user =>
+                  WorkPackageAssigneeType.user,
+                WorkPackageAssigneeTypeResponse.group =>
+                  WorkPackageAssigneeType.group,
+              },
+              title: e.assignee.title,
+            ),
+          ),
         )
         .toList();
+
+    return WorkPackagesPage(
+      items: items,
+      total: response.total,
+      count: response.count,
+      pageSize: response.pageSize,
+      offset: response.offset,
+    );
   }
 }

--- a/lib/modules/task_selection/infrastructure/local_settings_repository.dart
+++ b/lib/modules/task_selection/infrastructure/local_settings_repository.dart
@@ -12,6 +12,8 @@ class LocalSettingsRepository implements SettingsRepository {
   final String _workPackagesStatusFilterKey = 'workPackagesStatusFilter';
   final String _assigneeFilterKey = 'assigneeFilter';
   final String _analyticsConsent = 'analyticsConsent';
+  final String _showOnlyProjectsWithTasksKey = 'showOnlyProjectsWithTasks';
+  final String _doNotLoadProjectListKey = 'doNotLoadProjectList';
 
   // working hours
 
@@ -80,5 +82,27 @@ class LocalSettingsRepository implements SettingsRepository {
   @override
   Future<void> setAnalyticsConsent(bool value) async {
     await _storage.setBool(_analyticsConsent, value);
+  }
+
+  // project list filters
+
+  @override
+  Future<bool> get showOnlyProjectsWithTasks async {
+    return await _storage.getBool(_showOnlyProjectsWithTasksKey) ?? false;
+  }
+
+  @override
+  Future<void> setShowOnlyProjectsWithTasks(bool value) async {
+    await _storage.setBool(_showOnlyProjectsWithTasksKey, value);
+  }
+
+  @override
+  Future<bool> get doNotLoadProjectList async {
+    return await _storage.getBool(_doNotLoadProjectListKey) ?? false;
+  }
+
+  @override
+  Future<void> setDoNotLoadProjectList(bool value) async {
+    await _storage.setBool(_doNotLoadProjectListKey, value);
   }
 }

--- a/lib/modules/task_selection/infrastructure/projects_api.dart
+++ b/lib/modules/task_selection/infrastructure/projects_api.dart
@@ -17,11 +17,13 @@ abstract class ProjectsApi {
 
 class ProjectResponse {
   late String id;
+  int? numericId;
   late String title;
   late DateTime? updatedAt;
 
   ProjectResponse.fromJson(Map<String, dynamic> json) {
     id = json['identifier'];
+    numericId = (json['id'] as num?)?.toInt();
     title = json['name'];
     updatedAt = DateTime.tryParse(json['updatedAt']);
   }

--- a/lib/modules/task_selection/infrastructure/work_packages_api.dart
+++ b/lib/modules/task_selection/infrastructure/work_packages_api.dart
@@ -11,6 +11,7 @@ abstract class WorkPackagesApi {
   Future<WorkPackagesListResponse> workPackages({
     @Query('filters') String? filters,
     @Query('pageSize') int? pageSize,
+    @Query('offset') int? offset,
   });
 
   @GET('/projects/{projectId}/work_packages')
@@ -18,6 +19,7 @@ abstract class WorkPackagesApi {
     @Path() required projectId,
     @Query('filters') String? filters,
     @Query('pageSize') int? pageSize,
+    @Query('offset') int? offset,
   });
 }
 
@@ -74,7 +76,18 @@ class WorkPackageResponse {
 class WorkPackagesListResponse {
   late List<WorkPackageResponse> workPackages;
 
+  // Pagination metadata from OpenProject collection responses
+  late int total;
+  late int count;
+  int? pageSize;
+  int? offset;
+
   WorkPackagesListResponse.fromJson(Map<String, dynamic> json) {
+    total = (json['total'] as num?)?.toInt() ?? 0;
+    count = (json['count'] as num?)?.toInt() ?? 0;
+    pageSize = (json['pageSize'] as num?)?.toInt();
+    offset = (json['offset'] as num?)?.toInt();
+
     List<WorkPackageResponse> items = [];
     final embedded = json['_embedded'];
     final elements = embedded['elements'] as List<dynamic>;
@@ -82,5 +95,13 @@ class WorkPackagesListResponse {
       items.add(WorkPackageResponse.fromJson(element));
     }
     workPackages = items;
+
+    // Fallbacks in case the server omits meta fields.
+    if (count == 0) {
+      count = workPackages.length;
+    }
+    if (pageSize == null) {
+      pageSize = count;
+    }
   }
 }

--- a/lib/modules/task_selection/task_selection_module.dart
+++ b/lib/modules/task_selection/task_selection_module.dart
@@ -120,6 +120,9 @@ abstract class TaskSelectionModule {
   ) => WorkPackagesFilterBloc(statusesRepository, settingsRepository);
 
   @injectable
-  ProjectsListBloc projectsListBloc(ProjectsRepository projectsRepository) =>
-      ProjectsListBloc(projectsRepository);
+  ProjectsListBloc projectsListBloc(
+    ProjectsRepository projectsRepository,
+    SettingsRepository settingsRepository,
+    WorkPackagesRepository workPackagesRepository,
+  ) => ProjectsListBloc(projectsRepository, settingsRepository, workPackagesRepository);
 }

--- a/lib/modules/task_selection/ui/projects_list/projects_list_bloc.dart
+++ b/lib/modules/task_selection/ui/projects_list/projects_list_bloc.dart
@@ -1,14 +1,25 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:open_project_time_tracker/app/ui/bloc/bloc.dart';
 import 'package:open_project_time_tracker/modules/task_selection/domain/projects_repository.dart';
+import 'package:open_project_time_tracker/modules/task_selection/domain/settings_repository.dart';
+import 'package:open_project_time_tracker/modules/task_selection/domain/work_packages_repository.dart';
 
 part 'projects_list_bloc.freezed.dart';
 
 @freezed
 class ProjectsListState with _$ProjectsListState {
   const factory ProjectsListState.loading() = _Loading;
+  const factory ProjectsListState.notLoaded({
+    required bool showOnlyProjectsWithTasks,
+    required bool doNotLoadProjectList,
+    required String query,
+  }) = _NotLoaded;
   const factory ProjectsListState.idle({
+    required List<Project> allProjects,
     required List<Project> projects,
+    required String query,
+    required bool showOnlyProjectsWithTasks,
+    required bool doNotLoadProjectList,
   }) = _Idle;
 }
 
@@ -20,21 +31,168 @@ class ProjectsListEffect with _$ProjectsListEffect {
 class ProjectsListBloc
     extends EffectCubit<ProjectsListState, ProjectsListEffect> {
   final ProjectsRepository _projectsRepository;
+  final SettingsRepository _settingsRepository;
+  final WorkPackagesRepository _workPackagesRepository;
+
+  String _query = '';
+  bool _showOnlyProjectsWithTasks = false;
+  bool _doNotLoadProjectList = false;
 
   ProjectsListBloc(
     this._projectsRepository,
+    this._settingsRepository,
+    this._workPackagesRepository,
   ) : super(const ProjectsListState.loading());
 
-  Future<void> reload() async {
-    final projects = await _projectsRepository.list(
-      active: true,
-      pageSize: 200,
-      sortByName: true,
-      assignedToUser: true,
+  Future<void> onPageOpened() async {
+    await _loadSettings();
+
+    // If the user opted out of loading projects automatically, show an empty
+    // state that allows manual loading.
+    if (_doNotLoadProjectList) {
+      emit(
+        ProjectsListState.notLoaded(
+          showOnlyProjectsWithTasks: _showOnlyProjectsWithTasks,
+          doNotLoadProjectList: _doNotLoadProjectList,
+          query: _query,
+        ),
+      );
+      return;
+    }
+
+    await reload(showLoading: true);
+  }
+
+  Future<void> _loadSettings() async {
+    try {
+      _showOnlyProjectsWithTasks =
+          await _settingsRepository.showOnlyProjectsWithTasks;
+    } catch (_) {
+      _showOnlyProjectsWithTasks = false;
+    }
+
+    try {
+      _doNotLoadProjectList = await _settingsRepository.doNotLoadProjectList;
+    } catch (_) {
+      _doNotLoadProjectList = false;
+    }
+  }
+
+  void setQuery(String value) {
+    _query = value;
+    state.maybeWhen(
+      idle: (allProjects, projects, query, showOnly, doNotLoad) {
+        final filtered = _applyQuery(allProjects, _query);
+        emit(
+          ProjectsListState.idle(
+            allProjects: allProjects,
+            projects: filtered,
+            query: _query,
+            showOnlyProjectsWithTasks: showOnly,
+            doNotLoadProjectList: doNotLoad,
+          ),
+        );
+      },
+      notLoaded: (showOnly, doNotLoad, query) {
+        emit(
+          ProjectsListState.notLoaded(
+            showOnlyProjectsWithTasks: showOnly,
+            doNotLoadProjectList: doNotLoad,
+            query: _query,
+          ),
+        );
+      },
+      orElse: () {},
     );
+  }
+
+  List<Project> _applyQuery(List<Project> allProjects, String query) {
+    final q = query.trim().toLowerCase();
+    if (q.isEmpty) return allProjects;
+    return allProjects
+        .where((p) => p.title.toLowerCase().contains(q))
+        .toList();
+  }
+
+  String _projectKeyFromHref(String href) {
+    try {
+      final clean = href.split('?').first;
+      return clean.split('/').where((e) => e.isNotEmpty).last;
+    } catch (_) {
+      return href;
+    }
+  }
+
+  Future<void> reload({bool showLoading = false}) async {
+    await _loadSettings();
+    if (showLoading) {
+      emit(const ProjectsListState.loading());
+    }
+
+    List<Project> projects = [];
+    try {
+      projects = await _projectsRepository.list(
+        active: true,
+        pageSize: 200,
+        sortByName: true,
+        assignedToUser: true,
+      );
+    } catch (e) {
+      emit(
+        ProjectsListState.idle(
+          allProjects: const [],
+          projects: const [],
+          query: _query,
+          showOnlyProjectsWithTasks: _showOnlyProjectsWithTasks,
+          doNotLoadProjectList: _doNotLoadProjectList,
+        ),
+      );
+      emitEffect(const ProjectsListEffect.error());
+      return;
+    }
+
+    var filteredProjects = projects;
+
+    if (_showOnlyProjectsWithTasks) {
+      try {
+        final statuses = await _settingsRepository.workPackagesStatusFilter;
+        final assigneeFilter = await _settingsRepository.assigneeFilter;
+
+        // NOTE: OpenProject API is paginated. We request a large page size to
+        // keep this feature simple and avoid multiple requests. If the instance
+        // has more work packages than this limit, the filter may be incomplete.
+        final workPackages = await _workPackagesRepository.list(
+          projectId: null,
+          pageSize: 1000,
+          statuses: statuses,
+          user: assigneeFilter == 0 ? 'me' : null,
+        );
+
+        final projectKeys = workPackages
+            .map((wp) => _projectKeyFromHref(wp.projectHref))
+            .toSet();
+        final projectTitles = workPackages.map((wp) => wp.projectTitle).toSet();
+
+        filteredProjects = projects
+            .where(
+              (p) => projectKeys.contains(p.id) || projectTitles.contains(p.title),
+            )
+            .toList();
+      } catch (e) {
+        // If filtering fails, fall back to the unfiltered list.
+        filteredProjects = projects;
+      }
+    }
+
+    final visible = _applyQuery(filteredProjects, _query);
+
     emit(
       ProjectsListState.idle(
-        projects: projects,
+        allProjects: filteredProjects,
+        projects: visible,
+        query: _query,
+        showOnlyProjectsWithTasks: _showOnlyProjectsWithTasks,
+        doNotLoadProjectList: _doNotLoadProjectList,
       ),
     );
   }

--- a/lib/modules/task_selection/ui/projects_list/projects_list_bloc.dart
+++ b/lib/modules/task_selection/ui/projects_list/projects_list_bloc.dart
@@ -106,6 +106,12 @@ class ProjectsListBloc
     );
   }
 
+  /// In "Do not load project list" mode, projects are loaded only after the
+  /// user explicitly submits the search (which may be empty).
+  Future<void> submitSearch({bool showLoading = true}) async {
+    await reload(showLoading: showLoading);
+  }
+
   List<Project> _applyQuery(List<Project> allProjects, String query) {
     final q = query.trim().toLowerCase();
     if (q.isEmpty) return allProjects;

--- a/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
+++ b/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
@@ -51,7 +51,7 @@ class ProjectsListPage
             ),
           ],
         ),
-        notLoaded: (showOnlyProjectsWithTasks, doNotLoadProjectList, query) =>
+        notLoaded: (showOnlyProjectsWithTasks, doNotLoadProjectList, favoritesOnly, query) =>
             SliverMainAxisGroup(
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 12.0)),
@@ -92,6 +92,25 @@ class ProjectsListPage
                 ),
               ),
             ),
+
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  title: Text(
+                    AppLocalizations.of(context).projects_list__favorites_only,
+                  ),
+                  value: favoritesOnly,
+                  onChanged: (v) => context
+                      .read<ProjectsListBloc>()
+                      .setFavoritesOnly(v ?? false),
+                  controlAffinity: ListTileControlAffinity.leading,
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
             const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
           ],
         ),
@@ -102,6 +121,7 @@ class ProjectsListPage
           query,
           showOnlyProjectsWithTasks,
           doNotLoadProjectList,
+          favoritesOnly,
         ) => SliverMainAxisGroup(
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
@@ -117,6 +137,24 @@ class ProjectsListPage
                   ),
                   initialValue: query,
                   onChanged: context.read<ProjectsListBloc>().setQuery,
+                ),
+              ),
+            ),
+
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  title: Text(
+                    AppLocalizations.of(context).projects_list__favorites_only,
+                  ),
+                  value: favoritesOnly,
+                  onChanged: (v) => context
+                      .read<ProjectsListBloc>()
+                      .setFavoritesOnly(v ?? false),
+                  controlAffinity: ListTileControlAffinity.leading,
                 ),
               ),
             ),

--- a/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
+++ b/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
@@ -20,7 +20,7 @@ class ProjectsListPage
   @override
   void onCreate(BuildContext context, ProjectsListBloc bloc) {
     super.onCreate(context, bloc);
-    bloc.reload();
+    bloc.onPageOpened();
   }
 
   @override
@@ -40,7 +40,7 @@ class ProjectsListPage
   Widget buildState(BuildContext context, ProjectsListState state) {
     return SliverScreen(
       title: AppLocalizations.of(context).projects_list__title,
-      onRefresh: context.read<ProjectsListBloc>().reload,
+      onRefresh: () => context.read<ProjectsListBloc>().reload(showLoading: true),
       body: state.when(
         loading: () => const SliverMainAxisGroup(
           slivers: [
@@ -51,8 +51,62 @@ class ProjectsListPage
             ),
           ],
         ),
-        idle: (projects) => SliverMainAxisGroup(
+        notLoaded: (showOnlyProjectsWithTasks, doNotLoadProjectList, query) =>
+            SliverMainAxisGroup(
           slivers: [
+            const SliverToBoxAdapter(child: SizedBox(height: 12.0)),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: Text(
+                  AppLocalizations.of(context).projects_list__not_loaded_hint,
+                  style: const TextStyle(color: Colors.black54),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 12.0)),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: ElevatedButton.icon(
+                  onPressed: () => context
+                      .read<ProjectsListBloc>()
+                      .reload(showLoading: true),
+                  icon: const Icon(Icons.download_rounded),
+                  label: Text(
+                    AppLocalizations.of(context).projects_list__load_button,
+                  ),
+                ),
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
+          ],
+        ),
+        idle:
+            (
+          allProjects,
+          projects,
+          query,
+          showOnlyProjectsWithTasks,
+          doNotLoadProjectList,
+        ) => SliverMainAxisGroup(
+          slivers: [
+            const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                child: TextFormField(
+                  decoration: InputDecoration(
+                    hintText: AppLocalizations.of(context)
+                        .projects_list__search_hint,
+                    prefixIcon: const Icon(Icons.search),
+                    border: const OutlineInputBorder(),
+                  ),
+                  initialValue: query,
+                  onChanged: context.read<ProjectsListBloc>().setQuery,
+                ),
+              ),
+            ),
             const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
             SliverList(
               delegate: SliverChildBuilderDelegate(

--- a/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
+++ b/lib/modules/task_selection/ui/projects_list/projects_list_page.dart
@@ -68,14 +68,27 @@ class ProjectsListPage
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: ElevatedButton.icon(
-                  onPressed: () => context
-                      .read<ProjectsListBloc>()
-                      .reload(showLoading: true),
-                  icon: const Icon(Icons.download_rounded),
-                  label: Text(
-                    AppLocalizations.of(context).projects_list__load_button,
+                child: TextFormField(
+                  decoration: InputDecoration(
+                    hintText: AppLocalizations.of(context)
+                        .projects_list__search_hint,
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: IconButton(
+                      tooltip: AppLocalizations.of(context)
+                          .projects_list__load_button,
+                      onPressed: () => context
+                          .read<ProjectsListBloc>()
+                          .submitSearch(showLoading: true),
+                      icon: const Icon(Icons.search_rounded),
+                    ),
+                    border: const OutlineInputBorder(),
                   ),
+                  initialValue: query,
+                  textInputAction: TextInputAction.search,
+                  onChanged: context.read<ProjectsListBloc>().setQuery,
+                  onFieldSubmitted: (_) => context
+                      .read<ProjectsListBloc>()
+                      .submitSearch(showLoading: true),
                 ),
               ),
             ),


### PR DESCRIPTION
Added **totally untested** feature of filtered project listing with lazy autload.


### Adds Profile → Settings options :
- Show only projects with tasks
- Do not load project list automatically (lazy-load)

### Enhanced Project list screen
- Adds a text search field at the top of the project listing screen.
- In lazy-load mode, projects are loaded only after the user submits a search (even an empty search), so no background project loading happens.


Note:
The “projects with tasks” filter uses a single work packages query with a conservative pageSize (to keep the logic simple and avoid excessive API usage). If there are more results than the page size, the filter may be incomplete but should not break the UI.


Looking forward to see this feature in one of the upcoming official releases.